### PR TITLE
InnoDB enablement for submodule

### DIFF
--- a/sql/log.h
+++ b/sql/log.h
@@ -1,5 +1,6 @@
 /* Copyright (c) 2005, 2016, Oracle and/or its affiliates.
    Copyright (c) 2009, 2020, MariaDB Corporation.
+   Copyright (c) 2022, Intel Corporation.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1249,7 +1250,12 @@ static inline TC_LOG *get_tc_log_implementation()
     return &tc_log_dummy;
   if (opt_bin_log)
     return &mysql_bin_log;
+#ifdef NO_EDB_MODE
+//mmap does not work with enclave
   return &tc_log_mmap;
+#else
+  return &tc_log_dummy;
+#endif
 }
 
 #ifdef WITH_WSREP

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -2,6 +2,7 @@
 
 Copyright (c) 1995, 2021, Oracle and/or its affiliates. All Rights Reserved.
 Copyright (c) 2014, 2022, MariaDB Corporation.
+Copyright (c) 2022, Intel Corporation.
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
@@ -1258,16 +1259,21 @@ void fil_system_t::create(ulint hash_size)
 			    || dev_minor != unsigned(dev_minor)) {
 				continue;
 			}
+#ifdef NO_EDB_MODE
+			//makedev not available in enclave
 			ssd.push_back(makedev(unsigned(dev_major),
 					      unsigned(dev_minor)));
+#endif
 		}
 		closedir(d);
 	}
 	/* fil_system_t::is_ssd() assumes the following */
+#ifdef NO_EDB_MODE
 	ut_ad(makedev(0, 8) == 8);
 	ut_ad(makedev(0, 4) == 4);
 	ut_ad(makedev(0, 2) == 2);
 	ut_ad(makedev(0, 1) == 1);
+#endif
 #endif
 }
 

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -2,6 +2,7 @@
 
 Copyright (c) 1995, 2017, Oracle and/or its affiliates. All Rights Reserved.
 Copyright (c) 2013, 2022, MariaDB Corporation.
+Copyright (c) 2022, Intel Corporation.
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
@@ -1466,10 +1467,15 @@ public:
     /* Linux seems to allow up to 15 partitions per block device.
     If the detected ssd carries "partition number 0" (it is the whole device),
     compare the candidate file system number without the partition number. */
+#ifdef NO_EDB_MODE
     for (const auto s : ssd)
       if (dev == s || (dev & ~15U) == s)
         return true;
     return false;
+#else
+    //For enclave we assume that we use SSD
+    return true;
+#endif
   }
 #endif
 public:

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3,6 +3,7 @@
 Copyright (c) 1995, 2019, Oracle and/or its affiliates. All Rights Reserved.
 Copyright (c) 2009, Percona Inc.
 Copyright (c) 2013, 2022, MariaDB Corporation.
+Copyright (c) 2022, Intel Corporation.
 
 Portions of this file contain modifications contributed and copyrighted
 by Percona Inc.. Those modifications are
@@ -3100,6 +3101,8 @@ os_file_set_nocache(
 			" continuing anyway.";
 	}
 #elif defined(O_DIRECT)
+#ifdef NO_EDB_MODE
+        //O_DIRECT does not work with enclave
 	if (fcntl(fd, F_SETFL, O_DIRECT) == -1) {
 		int		errno_save = errno;
 		static bool	warning_message_printed = false;
@@ -3118,6 +3121,7 @@ os_file_set_nocache(
 				<< ", continuing anyway.";
 		}
 	}
+#endif
 #endif /* defined(UNIV_SOLARIS) && defined(DIRECTIO_ON) */
 }
 
@@ -3199,7 +3203,10 @@ fallback:
 		return(success);
 	}
 
+#ifdef NO_EDB_MODE
+	//FALLOCATE does not work in enclave
 # ifdef HAVE_POSIX_FALLOCATE
+
 	int err;
 	do {
 		if (fstat(file, &statbuf)) {
@@ -3234,6 +3241,7 @@ fallback:
 		break;
 	}
 # endif /* HAVE_POSIX_ALLOCATE */
+#endif
 #endif /* _WIN32*/
 
 #ifdef _WIN32


### PR DESCRIPTION
This is a subset of work which enables InnoDB engine within EdgelessDB. There is no significant functional changes here, it is mostly hiding under ifdefs the function calls which are not available within SGX enclave environment.